### PR TITLE
Favorites - Persistent sports reordering.

### DIFF
--- a/lib/route_generator.dart
+++ b/lib/route_generator.dart
@@ -1,4 +1,5 @@
 import 'package:capstone_hungry_hippos/screens/chat.dart';
+import 'package:capstone_hungry_hippos/screens/favorites_reorder.dart';
 import 'package:capstone_hungry_hippos/screens/schedule.dart';
 import 'package:capstone_hungry_hippos/screens/standing.dart';
 import 'package:flutter/material.dart';
@@ -6,10 +7,11 @@ import 'package:capstone_hungry_hippos/screens/home_widget.dart';
 import 'package:capstone_hungry_hippos/screens/sport.dart';
 
 class RouteGenerator {
-  static Route<dynamic> generateRoute(RouteSettings settings){
-    final args = settings.arguments; //This is how we pass arguments and can be used in case
+  static Route<dynamic> generateRoute(RouteSettings settings) {
+    final args = settings
+        .arguments; //This is how we pass arguments and can be used in case
 
-    switch (settings.name){
+    switch (settings.name) {
       case '/':
         return MaterialPageRoute(builder: (_) => Home());
       case '/Sport':
@@ -21,13 +23,15 @@ class RouteGenerator {
         return MaterialPageRoute(builder: (_) => Standing());
       case '/Chat':
         return MaterialPageRoute(builder: (_) => Chat());
+      case '/Favorites':
+        return MaterialPageRoute(builder: (_) => FavoritesManager());
       default:
         return _errorRoute();
     }
   }
 
   static Route _errorRoute() {
-    return MaterialPageRoute(builder: (_){
+    return MaterialPageRoute(builder: (_) {
       return Scaffold(
         appBar: AppBar(
           title: Text("Error Page"),

--- a/lib/screens/favorites_reorder.dart
+++ b/lib/screens/favorites_reorder.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class Favorites {
+  Future<SharedPreferences> _prefs = SharedPreferences.getInstance();
+
+  static const List<String> DEFAULT_FAVORITES = [
+    'Football',
+    'Basketball',
+    'Baseball',
+    'Soccer',
+    'Tennis',
+    'Volleyball'
+  ];
+
+  Future<List<String>> get_favorites() async {
+    final prefs = await _prefs;
+    return prefs.getStringList('favorites') ?? DEFAULT_FAVORITES;
+  }
+
+  Future<bool> set_favorites(final List<String> favorites) async {
+    final prefs = await _prefs;
+    return await prefs.setStringList('favorites', favorites);
+  }
+}
+
+class FavoritesManager extends StatefulWidget {
+  FavoritesManager({Key key}) : super(key: key);
+
+  @override
+  _FavoritesManagerState createState() => _FavoritesManagerState();
+}
+
+class _FavoritesManagerState extends State<FavoritesManager> {
+  Favorites _mgr = Favorites();
+  Future<List<String>> _order;
+
+  @override
+  void initState() {
+    _order = _mgr.get_favorites();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: false,
+        title: Text('Manage Favorites'),
+        backgroundColor: Colors.green,
+      ),
+      body: FutureBuilder<List<String>>(
+        future: _order,
+        builder: (ctx, snap) {
+          if (snap.connectionState == ConnectionState.waiting) {
+            return CircularProgressIndicator();
+          } else {
+            var order = snap.data.toList();
+            return ReorderableListView(
+              onReorder: (int oldIdx, int newIdx) {
+                if (newIdx > oldIdx) newIdx--;
+                order.insert(newIdx, order.removeAt(oldIdx));
+
+                setState(() {
+                  _mgr.set_favorites(order);
+                  _order = Future.value(order);
+                });
+              },
+              children: order.map((sport) {
+                return ListTile(
+                  key: Key(sport),
+                  title: Text(sport),
+                  trailing: Icon(Icons.drag_handle),
+                );
+              }).toList(),
+            );
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/home_widget.dart
+++ b/lib/screens/home_widget.dart
@@ -1,3 +1,5 @@
+import 'package:capstone_hungry_hippos/screens/favorites_reorder.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import '../news/feed.dart';
 
@@ -5,11 +7,20 @@ class Home extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: CustomScrollView(
-        slivers: <Widget>[
-          _AppBar(),
-          SliverList(delegate: SliverChildListDelegate(_buildList())),
-        ],
+      body: FutureBuilder(
+        future: _buildList(),
+        builder: (ctx, snap) {
+          if (snap.hasData) {
+            return CustomScrollView(
+              slivers: <Widget>[
+                _AppBar(),
+                SliverList(delegate: SliverChildListDelegate(snap.data)),
+              ],
+            );
+          } else {
+            return CircularProgressIndicator();
+          }
+        },
       ),
       drawer: Drawer(
         child: ListView(
@@ -35,7 +46,7 @@ class Home extends StatelessWidget {
             ListTile(
               title: IconButton(
                 icon: Icon(Icons.settings),
-                onPressed: ()=>Navigator.pushNamed(context, '/Favorites'),
+                onPressed: () => Navigator.pushNamed(context, '/Favorites'),
               ),
             )
           ],
@@ -56,15 +67,15 @@ class _AppBar extends StatelessWidget {
   }
 }
 
-List _buildList() {
+Future<List<HorizontalNewsFeed>> _buildList() async {
   final feed = Feed();
-  List<HorizontalNewsFeed> listItems = List();
-  listItems.add(HorizontalNewsFeed(newsFeed: feed, title: Text("Football")));
-  listItems.add(HorizontalNewsFeed(newsFeed: feed, title: Text("Soccer")));
-  listItems.add(HorizontalNewsFeed(newsFeed: feed, title: Text("Basketball")));
-  listItems.add(HorizontalNewsFeed(newsFeed: feed, title: Text("Volleyball")));
-  listItems.add(HorizontalNewsFeed(newsFeed: feed, title: Text("Baseball")));
-  listItems.add(HorizontalNewsFeed(newsFeed: feed, title: Text("Softball")));
-  listItems.add(HorizontalNewsFeed(newsFeed: feed, title: Text("Tennis")));
-  return listItems;
+  final mgr = Favorites();
+  final sports = await mgr.get_favorites();
+
+  return sports.map((sport) {
+    return HorizontalNewsFeed(
+      newsFeed: feed,
+      title: Text(sport),
+    );
+  }).toList();
 }

--- a/lib/screens/home_widget.dart
+++ b/lib/screens/home_widget.dart
@@ -32,6 +32,12 @@ class Home extends StatelessWidget {
                 onPressed: () => Navigator.pushNamed(context, '/Chat'),
               ),
             ),
+            ListTile(
+              title: IconButton(
+                icon: Icon(Icons.settings),
+                onPressed: ()=>Navigator.pushNamed(context, '/Favorites'),
+              ),
+            )
           ],
         ),
       ),

--- a/lib/screens/home_widget.dart
+++ b/lib/screens/home_widget.dart
@@ -3,7 +3,12 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import '../news/feed.dart';
 
-class Home extends StatelessWidget {
+class Home extends StatefulWidget {
+  @override
+  _HomeState createState() => _HomeState();
+}
+
+class _HomeState extends State<Home> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -46,7 +51,10 @@ class Home extends StatelessWidget {
             ListTile(
               title: IconButton(
                 icon: Icon(Icons.settings),
-                onPressed: () => Navigator.pushNamed(context, '/Favorites'),
+                onPressed: () =>
+                    Navigator.pushNamed(context, '/Favorites').then((e) {
+                  setState(() {});
+                }),
               ),
             )
           ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -88,6 +88,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   http:
     dependency: "direct main"
     description:
@@ -172,6 +177,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.23.1"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.6+3"
+  shared_preferences_macos:
+    dependency: transitive
+    description:
+      name: shared_preferences_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+6"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2+4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -242,4 +275,4 @@ packages:
     version: "3.5.0"
 sdks:
   dart: ">=2.6.0 <3.0.0"
-  flutter: ">=1.12.1"
+  flutter: ">=1.12.13+hotfix.4 <2.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,7 +101,7 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.4"
   image:
     dependency: transitive
     description:
@@ -218,7 +218,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.11"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_bloc: ^3.2.0
 
   http: ^0.12.0+4
+  shared_preferences: ^0.5.6+3
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
In the navigation drawer on the home page, click the new gear icon. The idea is this could be a place for other settings as well, but right now it only contains the sports reordering widget.

Tap and hold an item to enable movement, then drag it to the chosen position. When you go back to the main screen, the order will be correct, and the order will persist after app restart.

You will need to run `pub get` after pulling the changes, since I added a package to the `pubspec.yaml`. The library also works entirely async with `Future`s everywhere, so I had to rewrite some things in the main widget and convert it to be stateful.

But, that package should be super useful for any other options we want to add in future, and I think the general pattern I used with the `Favorites` and `FavoritesManager` classes will work alright.