### PR TITLE
filter article list to only contain correct sports

### DIFF
--- a/lib/news/feed.dart
+++ b/lib/news/feed.dart
@@ -20,11 +20,13 @@ class HorizontalNewsFeed extends StatelessWidget {
   final Feed newsFeed;
   final Text title;
   final double numCards;
+  final String sportFilter;
 
   const HorizontalNewsFeed({
     Key key,
     @required this.newsFeed,
     @required this.title,
+    @required this.sportFilter,
     this.numCards = 3.25,
   }) : super(key: key);
 
@@ -33,7 +35,8 @@ class HorizontalNewsFeed extends StatelessWidget {
   }
   @override
   Widget build(BuildContext context) {
-    //print(title.data);
+    var page = newsFeed.getPage(1, size: 100).then((page) => page.where((article) => article.sport.toLowerCase().contains(sportFilter.toLowerCase())).toList());
+
     return SizedBox(
       height: heightIn(context),
       child: Column(
@@ -55,7 +58,7 @@ class HorizontalNewsFeed extends StatelessWidget {
           ),
           Expanded(
             child: FutureBuilder(
-              future: newsFeed.getPage(1),
+              future: page,
               builder: (ctx, snapshot) {
                 if (!snapshot.hasData) {
                   return Center(child: CircularProgressIndicator());

--- a/lib/screens/favorites_reorder.dart
+++ b/lib/screens/favorites_reorder.dart
@@ -10,7 +10,6 @@ class Favorites {
     'Basketball',
     'Baseball',
     'Soccer',
-    'Tennis',
     'Volleyball'
   ];
 

--- a/lib/screens/home_widget.dart
+++ b/lib/screens/home_widget.dart
@@ -96,6 +96,7 @@ Future<List<HorizontalNewsFeed>> _buildList() async {
     return HorizontalNewsFeed(
       newsFeed: feed,
       title: Text(sport),
+      sportFilter: sport,
     );
   }).toList();
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,21 +7,21 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
+    version: "2.0.11"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "1.5.2"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.0"
   bloc:
     dependency: transitive
     description:
@@ -35,21 +35,21 @@ packages:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.0.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.14.11"
   convert:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.3"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -113,7 +113,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.4"
   intl:
     dependency: transitive
     description:
@@ -176,7 +176,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.0.5"
   rxdart:
     dependency: transitive
     description:
@@ -230,7 +230,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.5.5"
   stack_trace:
     dependency: transitive
     description:
@@ -272,7 +272,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.11"
   typed_data:
     dependency: transitive
     description:
@@ -293,7 +293,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.6.1"
+    version: "3.5.0"
 sdks:
   dart: ">=2.6.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.4 <2.0.0"


### PR DESCRIPTION
Just doing a simple string comparison test on the "sport" field for each article with the name of the sport. Actual value might be "DI Men's Basketball" or "DI Women's Basketball" but those both get caught by "Basketball" and included in that feed.

Increased article page size to 100 so that all the sports have a few pages. Tennis has absolutely no articles, so I just removed it from the homepage.